### PR TITLE
Added support for optional callback when scheduled jobs are done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ node_js:
   - "iojs"
 before_script: npm run lint
 script: ./node_modules/.bin/istanbul cover ./node_modules/.bin/nodeunit test && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
   - "iojs"
 before_script: npm run lint
 script: ./node_modules/.bin/istanbul cover ./node_modules/.bin/nodeunit test && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage
+

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -20,8 +20,16 @@ function Job(name, job, callback) {
 
   // Set scope vars
   var jobName = name && typeof name === 'string' ? name : '<Anonymous Job ' + (++anonJobCounter) + '>';
-  this.job = job || name;
-  this.callback = callback || false;
+  this.job = name && typeof name === 'function' ? name : job;
+
+  // Make sure callback is actually a callback
+  if (this.job === name) {
+    // Name wasn't provided and maybe a callback is there
+    this.callback = job || false;
+  } else {
+    // Name was provided, and maybe a callback is there
+    this.callback = callback || false;
+  }
 
   // define properties
   Object.defineProperty(this, 'name', {

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -14,31 +14,18 @@ var events = require('events'),
 /* Job object */
 var anonJobCounter = 0;
 
-function Job() {
-  var name;
-
-  // process arguments to the constructor
-  var arg;
-  for (var i = 0; i < arguments.length; i++) {
-    arg = arguments[i];
-    if (typeof arg == 'string' || arg instanceof String) {
-      name = arg;
-    } else {
-      this.job = arg;
-    }
-  }
-
-  // give us a random name if one wasn't provided
-  if (name == null) {
-    name = '<Anonymous Job ' + (++anonJobCounter) + '>';
-  }
-
+function Job(name, job, callback) {
   // setup a private pendingInvocations variable
   var pendingInvocations = [];
 
+  // Set scope vars
+  var jobName = name && typeof name === 'string' ? name : '<Anonymous Job ' + (++anonJobCounter) + '>';
+  this.job = job || name;
+  this.callback = callback || false;
+
   // define properties
   Object.defineProperty(this, 'name', {
-    value: name,
+    value: jobName,
     writable: false,
     enumerable: true
   });
@@ -388,6 +375,10 @@ function prepareNextInvocation() {
     currentInvocation.timerID = runOnDate(currentInvocation.fireDate, function() {
       currentInvocationFinished();
 
+      if (job.callback && typeof job.callback === 'function') {
+        job.callback();
+      }
+
       if (cinv.recurrenceRule.recurs || cinv.recurrenceRule._endDate === null) {
         var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, cinv.fireDate);
         if (inv !== null) {
@@ -449,11 +440,12 @@ function scheduleJob() {
     return null;
   }
 
-  var name = (arguments.length >= 3) ? arguments[0] : null;
-  var spec = (arguments.length >= 3) ? arguments[1] : arguments[0];
-  var method = (arguments.length >= 3) ? arguments[2] : arguments[1];
+  var name = (arguments.length >= 4) ? arguments[0] : null;
+  var spec = (arguments.length >= 4) ? arguments[1] : arguments[0];
+  var method = (arguments.length >= 4) ? arguments[2] : arguments[1];
+  var callback = (arguments.length >= 4) ? arguments[3] : arguments[2];
 
-  var job = new Job(name, method);
+  var job = new Job(name, method, callback);
 
   if (job.schedule(spec)) {
     scheduledJobs[job.name] = job;

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -25,10 +25,10 @@ function Job(name, job, callback) {
   // Make sure callback is actually a callback
   if (this.job === name) {
     // Name wasn't provided and maybe a callback is there
-    this.callback = job || false;
+    this.callback = typeof job === 'function' ? job : false;
   } else {
     // Name was provided, and maybe a callback is there
-    this.callback = callback || false;
+    this.callback = typeof callback === 'function' ? callback : false;
   }
 
   // define properties
@@ -383,7 +383,7 @@ function prepareNextInvocation() {
     currentInvocation.timerID = runOnDate(currentInvocation.fireDate, function() {
       currentInvocationFinished();
 
-      if (job.callback && typeof job.callback === 'function') {
+      if (job.callback) {
         job.callback();
       }
 

--- a/test/convenience-method-test.js
+++ b/test/convenience-method-test.js
@@ -255,7 +255,6 @@ module.exports = {
         test.ok(true);
       });
 
-
       setTimeout(function() {
         schedule.cancelJob(job.name);
       }, 2250);

--- a/test/convenience-method-test.js
+++ b/test/convenience-method-test.js
@@ -167,6 +167,24 @@ module.exports = {
           }, 1000);
         }*/
   },
+  ".scheduleJob({...}, {...}, fn)": {
+    "Callback called for each job if callback is provided": function(test) {
+      test.expect(3);
+
+      var job = new schedule.scheduleJob({
+        second: null // Fire every second
+      }, function() {}, function() {
+        test.ok(true);
+      });
+
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 3250);
+
+      clock.tick(3250);
+    }
+  },
   ".cancelJob(Job)": {
     "Prevents all future invocations of Job passed in": function(test) {
       test.expect(2);
@@ -236,6 +254,7 @@ module.exports = {
       }, function() {
         test.ok(true);
       });
+
 
       setTimeout(function() {
         schedule.cancelJob(job.name);

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -70,7 +70,7 @@ module.exports = {
       });
 
       job.runOnDate(new Date(Date.now() + 3000));
-     
+
       setTimeout(function() {
         test.done();
       }, 3250);
@@ -245,6 +245,26 @@ module.exports = {
           test.done();
           }, 1000);
         }*/
+  },
+  "#schedule({...}, {...})": {
+    "Runs job and run callback when job is done if callback is provided": function(test) {
+      test.expect(3);
+
+      var job = new schedule.Job(function() {}, function() {
+        test.ok(true);
+      });
+
+      job.schedule({
+        second: null // fire every second
+      });
+
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 3250);
+
+      clock.tick(3250);
+    }
   },
   "#cancel": {
     "Prevents all future invocations": function(test) {

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -125,6 +125,23 @@ module.exports = {
       clock.tick(3250);
     }
   },
+  "#schedule(Date, fn)": {
+    "Runs job once at some date, calls callback when done": function(test) {
+      test.expect(1);
+
+      var job = new schedule.Job(function() {}, function() {
+        test.ok(true);
+      });
+
+      job.schedule(new Date(Date.now() + 3000));
+
+      setTimeout(function() {
+        test.done();
+      }, 3250);
+
+      clock.tick(3250);
+    }
+  },
   "#schedule(RecurrenceRule)": {
     "Runs job at interval based on recur rule, repeating indefinitely": function(test) {
       test.expect(3);


### PR DESCRIPTION
I added support for an optional callback to be fired if provided when **job** is completed- just an extension of ``Job``. 

I also wasn't quite sure for the reason of this block:

```javascript
var arg;
for (var i = 0; i < arguments.length; i++) {
   arg = arguments[i];
    if (typeof arg == 'string' || arg instanceof String) {
      name = arg;
    } else {
      this.job = arg;
    }
  }
```

Instead of accessing the arguments obj, I just pass in the parameters to the class directly, to allow for more flexibility and removing the loop. If there was a reason, feel free to stop me and explain the method to the madness.

Cheers.