### PR TITLE
Allow for varying an invocations fireDate by a specified number of seconds

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -186,6 +186,9 @@ Job.prototype.schedule = function(spec) {
         if ('second' in spec) {
           r.second = spec.second;
         }
+        if ('variation' in spec) {
+          r.variation = spec.variation;
+        }
 
         spec = r;
       }
@@ -223,6 +226,15 @@ function Invocation(job, fireDate, recurrenceRule) {
   this.recurrenceRule = recurrenceRule || DoesntRecur;
 
   this.timerID = null;
+
+  if (this.recurrenceRule.variation != 0){
+    var variation = getRandomVariation(this.recurrenceRule.variation);
+    this.fireDate.setTime(this.fireDate.getTime() + (variation * 1000));
+  }
+}
+
+function getRandomVariation(variation) {
+  return Math.floor(Math.random() * (variation - (variation * -1))) + (variation * -1);
 }
 
 function sorter(a, b) {
@@ -260,7 +272,7 @@ Range.prototype.contains = function(val) {
 
   NOTE: Cron months are 1-based, but RecurrenceRule months are 0-based.
 */
-function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
+function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second, variation) {
   this.recurs = true;
 
   this.year = (year == null) ? null : year;
@@ -270,6 +282,8 @@ function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
   this.hour = (hour == null) ? null : hour;
   this.minute = (minute == null) ? null : minute;
   this.second = (second == null) ? 0 : second;
+
+  this.variation = (variation == null) ? 0 : variation;
 }
 
 RecurrenceRule.prototype.nextInvocationDate = function(base) {

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -224,13 +224,13 @@ function Invocation(job, scheduleDate, recurrenceRule) {
 
   this.timerID = null;
 
-  if (this.recurrenceRule.variation && this.recurrenceRule.variation != 0){
+  if (this.recurrenceRule.variation && this.recurrenceRule.variation !== 0) {
     var variation = Math.floor(this.random() * this.recurrenceRule.variation * 2) + (this.recurrenceRule.variation * -1);
     this.fireDate.setTime(this.fireDate.getTime() + (variation * 1000));
   }
 }
 
-Invocation.prototype.random = function(){
+Invocation.prototype.random = function() {
   return Math.random();
 };
 

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -403,7 +403,8 @@ function prepareNextInvocation() {
       currentInvocationFinished();
 
       if (cinv.recurrenceRule.recurs || cinv.recurrenceRule._endDate === null) {
-        var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, cinv.fireDate);
+        var newInvFrom = new Date(cinv.fireDate.setTime(cinv.fireDate.getTime() + (cinv.recurrenceRule.variation * 2000)));
+        var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, newInvFrom); //var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, cinv.fireDate);
         if (inv !== null) {
           inv.job.trackInvocation(inv);
         }

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -68,7 +68,7 @@ function Job(name, job, callback) {
       cancelInvocation(inv);
 
       if (reschedule && inv.recurrenceRule.recurs) {
-        newInv = scheduleNextRecurrence(inv.recurrenceRule, this, inv.fireDate);
+        newInv = scheduleNextRecurrence(inv.recurrenceRule, this, inv.scheduleDate);
         if (newInv !== null) {
           newInvs.push(newInv);
         }
@@ -103,7 +103,7 @@ function Job(name, job, callback) {
     cancelInvocation(nextInv);
 
     if (reschedule && nextInv.recurrenceRule.recurs) {
-      newInv = scheduleNextRecurrence(nextInv.recurrenceRule, this, nextInv.fireDate);
+      newInv = scheduleNextRecurrence(nextInv.recurrenceRule, this, nextInv.scheduleDate);
       if (newInv !== null) {
         this.trackInvocation(newInv);
       }
@@ -216,22 +216,23 @@ var DoesntRecur = new RecurrenceRule();
 DoesntRecur.recurs = false;
 
 /* Invocation object */
-function Invocation(job, fireDate, recurrenceRule) {
+function Invocation(job, scheduleDate, recurrenceRule) {
   this.job = job;
-  this.fireDate = fireDate;
+  this.scheduleDate = scheduleDate;
+  this.fireDate = new Date(scheduleDate.valueOf());
   this.recurrenceRule = recurrenceRule || DoesntRecur;
 
   this.timerID = null;
 
-  if (this.recurrenceRule.variation != 0){
-    var variation = getRandomVariation(this.recurrenceRule.variation);
+  if (this.recurrenceRule.variation && this.recurrenceRule.variation != 0){
+    var variation = Math.floor(this.random() * this.recurrenceRule.variation * 2) + (this.recurrenceRule.variation * -1);
     this.fireDate.setTime(this.fireDate.getTime() + (variation * 1000));
   }
 }
 
-function getRandomVariation(variation) {
-  return Math.floor(Math.random() * (variation - (variation * -1))) + (variation * -1);
-}
+Invocation.prototype.random = function(){
+  return Math.random();
+};
 
 function sorter(a, b) {
   return (a.fireDate.getTime() - b.fireDate.getTime());
@@ -403,8 +404,7 @@ function prepareNextInvocation() {
       }
 
       if (cinv.recurrenceRule.recurs || cinv.recurrenceRule._endDate === null) {
-        var newInvFrom = new Date(cinv.fireDate.setTime(cinv.fireDate.getTime() + (cinv.recurrenceRule.variation * 2000)));
-        var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, newInvFrom); //var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, cinv.fireDate);
+        var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, cinv.scheduleDate);
         if (inv !== null) {
           inv.job.trackInvocation(inv);
         }

--- a/test/convenience-method-test.js
+++ b/test/convenience-method-test.js
@@ -167,6 +167,25 @@ module.exports = {
           }, 1000);
         }*/
   },
+  ".scheduleJob({...}, fn)": {
+    "Runs job at interval based on object, repeating indefinitely, with 5 second variation": function(test) {
+      test.expect(4);
+
+      var job = new schedule.scheduleJob({
+        second: [0,15,30,45],
+        variation: 5
+      }, function() {
+        test.ok(true);
+      });
+
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 65250);
+
+      clock.tick(65250);
+    }
+  },
   ".scheduleJob({...}, {...}, fn)": {
     "Callback called for each job if callback is provided": function(test) {
       test.expect(3);

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -118,7 +118,7 @@ module.exports = {
       });
 
       job.on('scheduled', function(runAtDate) {
-        test.equal(runAtDate, date);
+        test.deepEqual(runAtDate, date);
       });
 
       job.schedule(date);

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -255,6 +255,60 @@ module.exports = {
       test.deepEqual(new Date(2011, 5, 1, 0, 0, 0, 0), next);
 
       test.done();
+    },
+    "specify 5 second variation (test that variation is within specified range)": function(test) {
+      test.expect(8);
+
+      var rule = new schedule.RecurrenceRule();
+      rule.second = [0,15,30,45];
+      rule.variation = 5;
+
+      var scheduledDates = [
+        new Date(2010, 3, 29, 12, 30, 30, 0),
+        new Date(2010, 3, 29, 12, 30, 45, 0),
+        new Date(2010, 3, 29, 12, 31, 00, 0),
+        new Date(2010, 3, 29, 12, 31, 15, 0)
+      ]
+
+      var next = base;
+      scheduledDates.forEach(function(date){
+        var inv = new schedule.Invocation(null, rule.nextInvocationDate(next), rule);
+        next = inv.scheduleDate;
+
+        test.deepEqual(date, inv.scheduleDate);
+        test.ok(Math.abs(inv.fireDate - inv.scheduleDate) <= 5000);
+      });
+
+      test.done();
+    },
+    "specify 5 second variation (override variation to test exact fireDate)": function(test) {
+      test.expect(8);
+
+      var rule = new schedule.RecurrenceRule();
+      rule.second = [0,15,30,45];
+      rule.variation = 5;
+
+      schedule.Invocation.prototype.random = function(){
+        return 0.7;
+      };
+
+      var scheduledDates = [
+        new Date(2010, 3, 29, 12, 30, 30, 0),
+        new Date(2010, 3, 29, 12, 30, 45, 0),
+        new Date(2010, 3, 29, 12, 31, 00, 0),
+        new Date(2010, 3, 29, 12, 31, 15, 0)
+      ]
+
+      var next = base;
+      scheduledDates.forEach(function(date){
+        var inv = new schedule.Invocation(null, rule.nextInvocationDate(next), rule);
+        next = inv.scheduleDate;
+
+        test.deepEqual(date, inv.scheduleDate);
+        test.deepEqual(inv.fireDate, new Date(inv.scheduleDate.getTime() + 2000));
+      });
+
+      test.done();
     }
   }
 };


### PR DESCRIPTION
I required functionality to randomly vary my invocations by a specified range, for example, specifying a schedule for every hour, but allowing a variation of 5 minutes, in which case the 12:00 Invocation may run at anytime between 11:55 - 12:05.

Although this is relatively specific functionality I assume that it may be useful to others, so decided to create this Pull Request.

All existing functionality remains unchanged, but a new `variation` property is available on the rule object, which if specified will adjust the resulting invocations accordingly.

```javascript
var rule = new schedule.RecurrenceRule();
rule.minute = 0;
rule.variation = 300;

var j = schedule.scheduleJob(rule, function(){
    console.log('within 5 minutes before or after the hour');
});
```

I've also added some associated tests.